### PR TITLE
Fix: Optimize Puppeteer launch and navigation for CI

### DIFF
--- a/script/extractAll.js
+++ b/script/extractAll.js
@@ -1,6 +1,7 @@
 import puppeteer from 'puppeteer';
 import { saveData } from './services/mongoConnection.js';
 import config from '../config.js';
+import process from 'process';
 
 //const selectors:::
 const table = '.results-list';
@@ -23,10 +24,24 @@ const regexNumber = /[0-9]{1,2}/gm;
   const allResults = [];
 
   //puppet config:::
-  const browser = await puppeteer.launch({ headless: true, defaultViewport: null, args: ['--start-maximized', '--no-sandbox' ] });
+  const isCI = !!process.env.CI;
+  const browser = await puppeteer.launch({
+    headless: isCI ? 'shell' : true,
+    defaultViewport: null,
+    args: [
+      '--start-maximized',
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+    ],
+  });
   const page = await browser.newPage();
   await page.setUserAgent(userAgent);
-  await page.goto(config.URL ?? '');
+  await page.goto(config.URL ?? '', {
+    waitUntil: isCI ? 'domcontentloaded' : 'load',
+    timeout: 60000,
+  });
   await page.waitForSelector(table);
   await page.waitForSelector(iconPlus);
 

--- a/script/extractAll.js
+++ b/script/extractAll.js
@@ -38,9 +38,11 @@ const regexNumber = /[0-9]{1,2}/gm;
   });
   const page = await browser.newPage();
   await page.setUserAgent(userAgent);
-  await page.goto(config.URL ?? '', {
+  if (isCI) {
+    page.setDefaultTimeout(60000);
+  }
+  await page.goto(config.URL, {
     waitUntil: isCI ? 'domcontentloaded' : 'load',
-    timeout: 60000,
   });
   await page.waitForSelector(table);
   await page.waitForSelector(iconPlus);


### PR DESCRIPTION
### Description of Changes

This PR optimizes Puppeteer launch parameters and page navigation configurations when running in CI environments (GitHub Actions) to resolve the navigation timeout issue.

Closes #16

### Key Changes

1. **Auto-Detect CI:** Checks for the presence of the `process.env.CI` environment variable.
2. **CI-tuned flags:** Added flags to avoid Chromium hangs and crashes:
   - `--disable-dev-shm-usage`: Uses `/tmp` instead of the limited `/dev/shm` partition.
   - `--disable-gpu`: Disables hardware acceleration.
   - `--disable-setuid-sandbox`: Avoids sandboxing issues.
   - `headless: 'shell'`: Uses the classic lightweight headless engine in Puppeteer.
3. **Resilient page load:**
   - Wait condition set to `domcontentloaded` when in CI (so it doesn't hang on tracker scripts or assets).
   - Increased navigation timeout to `60000ms`.

### Verification

- Successfully ran extraction script locally (`node script/extractAll.js`).
